### PR TITLE
Add a new tryx_join macro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
         run: cargo clippy --all-features --all-targets
       - name: Lint (rustfmt)
         run: cargo xfmt --check
+      - name: Run rustdoc
+        env:
+          RUSTC_BOOTSTRAP: 1  # for feature(doc_cfg)
+          RUSTDOCFLAGS: -Dwarnings --cfg doc_cfg
+        run: cargo doc --all-features --workspace
       - name: Check for differences
         run: git diff --exit-code
 
@@ -45,6 +50,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-hack
       - name: Build
-        run: cargo hack --feature-powerset build
+        run: ./scripts/with-feature-powerset.sh build
       - name: Test
-        run: cargo hack --feature-powerset test
+        run: ./scripts/with-feature-powerset.sh test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build rustdoc
+        env:
+          RUSTC_BOOTSTRAP: 1  # for feature(doc_cfg)
+          RUSTDOCFLAGS: -Dwarnings --cfg doc_cfg
         run: cargo doc --all-features --workspace
       - name: Organize
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,21 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Alternative futures adapters that are safe to cancel"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg=doc_cfg"]
+
 [dependencies]
 futures-core = { version = "0.3.28", default-features = false }
 futures-sink = { version = "0.3.28", default-features = false }
 futures-util = { version = "0.3.28", default-features = false, features = ["sink"] }
+tokio = { version = "1.28.2", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.28.2", features = ["rt", "macros", "time"] }
+anyhow = "1.0.72"
+tempfile = "3.6.0"
+tokio = { version = "1.28.2", features = ["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync", "time"] }
+tokio-test = "0.4.0"
 
 [features]
 # These features are not currently used, however they're here to ensure
@@ -19,3 +27,8 @@ tokio = { version = "1.28.2", features = ["rt", "macros", "time"] }
 default = ["std"]
 std = ["alloc", "futures-core/std", "futures-sink/std", "futures-util/std"]
 alloc = ["futures-core/alloc", "futures-sink/alloc", "futures-util/alloc"]
+
+macros = []
+
+# Internal-only feature, used for documentation and doctests. Not part of the public API.
+internal-docs = ["dep:tokio", "tokio?/io-util", "tokio?/macros", "tokio?/rt"]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Alternative futures adapters that are more cancel-safe.
 
 ## What is this crate?
 
+This crate solves two related but distinct problems:
+
+### Cancel-safe futures adapters
+
 The [`futures`](https://docs.rs/futures/latest/futures/) library contains many adapters that
 make writing asynchronous Rust code more pleasant. However, some of those combinators make it
 hard to write code that can withstand cancellation in the case of timeouts, `select!` branches
@@ -15,10 +19,7 @@ or similar.
 
 For a more detailed explanation, see the documentation for [`SinkExt::reserve`].
 
-This crate contains alternative adapters that are designed for use in scenarios where
-cancellation is expected.
-
-## Example
+#### Example
 
 Attempt to send an item in a loop with a timeout:
 
@@ -54,7 +55,22 @@ while item.is_some() {
 
 ```
 
+### `tryx` adapters that don't perform cancellations
+
+The futures and tokio libraries come with a number of `try_` adapters and macros, for example
+[`tokio::try_join!`]. These adapters have the property that if one of the futures under
+consideration fails, all other futures are cancelled.
+
+This is not always desirable and has led to correctness bugs (e.g. [omicron
+##3707](https://github.com/oxidecomputer/omicron/pull/3707)). To address this issue, this crate
+provides a set of `tryx` adapters and macros that behave like their `try_` counterparts, except
+that even if one of the futures errors out the others will be run to completion.
+
+For a detailed example, see the documentation for the [`tryx_join`] macro.
+
 ## Optional features
+
+* `macros`: Enables macros.
 
 The `std` and `alloc` features are defined and enabled by default, but not currently used.
 No-std users must turn off default features while importing this crate.
@@ -66,6 +82,8 @@ license](LICENSE-MIT).
 
 Portions derived from [futures-rs](https://github.com/rust-lang/futures-rs), and used under the
 Apache 2.0 and MIT licenses.
+
+Portions derived from [tokio](https://github.com/tokio-rs/tokio), and used under the MIT license.
 
 <!--
 README.md is generated from README.tpl by cargo readme. To regenerate:

--- a/README.tpl
+++ b/README.tpl
@@ -14,6 +14,8 @@ license](LICENSE-MIT).
 Portions derived from [futures-rs](https://github.com/rust-lang/futures-rs), and used under the
 Apache 2.0 and MIT licenses.
 
+Portions derived from [tokio](https://github.com/tokio-rs/tokio), and used under the MIT license.
+
 <!--
 README.md is generated from README.tpl by cargo readme. To regenerate:
 

--- a/scripts/with-feature-powerset.sh
+++ b/scripts/with-feature-powerset.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+# Run commands to build and test with a feature powerset. Requires `cargo-hack` to be installed.
+
+EXCLUDED_FEATURES=(internal-docs)
+
+joined_excluded_features=$(printf ",%s" "${EXCLUDED_FEATURES[@]}")
+# Strip leading comma
+joined_excluded_features=${joined_excluded_features:1}
+
+run_build() {
+    check_cargo_hack
+
+    echo_err "Running non-dev build" >&2
+    run_cargo_hack build
+
+    echo_err "Running dev build"
+    run_cargo_hack build --all-targets
+}
+
+run_test() {
+    check_cargo_hack
+
+    echo_err "Running non-doc tests"
+    run_cargo_hack test --lib --bins --tests --benches --examples
+
+    echo_err "Running doctests"
+    cargo test --all-features --doc
+}
+
+echo_err() {
+    echo "$@" >&2
+}
+
+check_cargo_hack() {
+    if ! cargo hack --version >/dev/null 2>&1; then
+        echo_err "cargo-hack not installed. Install it with:"
+        echo_err "    cargo install cargo-hack"
+        exit 1
+    fi
+}
+
+run_cargo_hack() {
+    cargo hack --feature-powerset --exclude-features "$joined_excluded_features" "$@"
+}
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        b|build) run_build ;;
+        t|test) run_test ;;
+        -h|--help) echo "Usage: with-feature-powerset.sh [b|build|t|test]"; exit 0 ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,10 @@
 //!
 //! # What is this crate?
 //!
+//! This crate solves two related but distinct problems:
+//!
+//! ## Cancel-safe futures adapters
+//!
 //! The [`futures`](https://docs.rs/futures/latest/futures/) library contains many adapters that
 //! make writing asynchronous Rust code more pleasant. However, some of those combinators make it
 //! hard to write code that can withstand cancellation in the case of timeouts, `select!` branches
@@ -11,10 +15,7 @@
 //!
 //! For a more detailed explanation, see the documentation for [`SinkExt::reserve`].
 //!
-//! This crate contains alternative adapters that are designed for use in scenarios where
-//! cancellation is expected.
-//!
-//! # Example
+//! ### Example
 //!
 //! Attempt to send an item in a loop with a timeout:
 //!
@@ -56,10 +57,36 @@
 //! # Ok(()) }
 //! ```
 //!
+//! ## `tryx` adapters that don't perform cancellations
+//!
+//! The futures and tokio libraries come with a number of `try_` adapters and macros, for example
+//! [`tokio::try_join!`]. These adapters have the property that if one of the futures under
+//! consideration fails, all other futures are cancelled.
+//!
+//! This is not always desirable and has led to correctness bugs (e.g. [omicron
+//! #3707](https://github.com/oxidecomputer/omicron/pull/3707)). To address this issue, this crate
+//! provides a set of `tryx` adapters and macros that behave like their `try_` counterparts, except
+//! that even if one of the futures errors out the others will be run to completion.
+//!
+//! For a detailed example, see the documentation for the [`tryx_join`] macro.
+//!
 //! # Optional features
+//!
+//! * `macros`: Enables macros.
 //!
 //! The `std` and `alloc` features are defined and enabled by default, but not currently used.
 //! No-std users must turn off default features while importing this crate.
+
+#![warn(missing_docs)]
+#![cfg_attr(doc_cfg, feature(doc_cfg, doc_auto_cfg))]
+
+// Includes re-exports used by macros.
+//
+// This module is not intended to be part of the public API. In general, any
+// `doc(hidden)` code is not part of Tokio's public and stable API.
+#[macro_use]
+#[doc(hidden)]
+pub mod macros;
 
 pub mod prelude;
 pub mod sink;

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -1,0 +1,3 @@
+#[doc(hidden)]
+pub mod support;
+mod tryx_join;

--- a/src/macros/support.rs
+++ b/src/macros/support.rs
@@ -1,0 +1,78 @@
+//! Definition of the MaybeDone combinator.
+
+use core::mem;
+pub use core::{
+    future::{poll_fn, Future},
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// A future that may have completed.
+#[derive(Debug)]
+pub enum MaybeDone<Fut: Future> {
+    /// A not-yet-completed future.
+    Future(Fut),
+    /// The output of the completed future.
+    Done(Fut::Output),
+    /// The empty variant after the result of a [`MaybeDone`] has been
+    /// taken using the [`take_output`](MaybeDone::take_output) method.
+    Gone,
+}
+
+// Safe because we never generate `Pin<&mut Fut::Output>`
+impl<Fut: Future + Unpin> Unpin for MaybeDone<Fut> {}
+
+/// Wraps a future into a `MaybeDone`.
+pub fn maybe_done<Fut: Future>(future: Fut) -> MaybeDone<Fut> {
+    MaybeDone::Future(future)
+}
+
+impl<Fut: Future> MaybeDone<Fut> {
+    /// Returns an [`Option`] containing a mutable reference to the output of the future.
+    /// The output of this method will be [`Some`] if and only if the inner
+    /// future has been completed and [`take_output`](MaybeDone::take_output)
+    /// has not yet been called.
+    pub fn output_mut(self: Pin<&mut Self>) -> Option<&mut Fut::Output> {
+        unsafe {
+            let this = self.get_unchecked_mut();
+            match this {
+                MaybeDone::Done(res) => Some(res),
+                _ => None,
+            }
+        }
+    }
+
+    /// Attempts to take the output of a `MaybeDone` without driving it
+    /// towards completion.
+    #[inline]
+    pub fn take_output(self: Pin<&mut Self>) -> Option<Fut::Output> {
+        unsafe {
+            let this = self.get_unchecked_mut();
+            match this {
+                MaybeDone::Done(_) => {}
+                MaybeDone::Future(_) | MaybeDone::Gone => return None,
+            };
+            if let MaybeDone::Done(output) = mem::replace(this, MaybeDone::Gone) {
+                Some(output)
+            } else {
+                unreachable!()
+            }
+        }
+    }
+}
+
+impl<Fut: Future> Future for MaybeDone<Fut> {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let res = unsafe {
+            match self.as_mut().get_unchecked_mut() {
+                MaybeDone::Future(a) => core::task::ready!(Pin::new_unchecked(a).poll(cx)),
+                MaybeDone::Done(_) => return Poll::Ready(()),
+                MaybeDone::Gone => panic!("MaybeDone polled after value taken"),
+            }
+        };
+        self.set(MaybeDone::Done(res));
+        Poll::Ready(())
+    }
+}

--- a/src/macros/tryx_join.rs
+++ b/src/macros/tryx_join.rs
@@ -1,0 +1,210 @@
+/// Waits on multiple concurrent branches for **all** futures to complete, returning Ok(_) or an
+/// error.
+///
+/// Unlike [`tokio::try_join`], this macro does not cancel remaining futures if one of them returns
+/// an error. Instead, this macro runs all futures to completion.
+///
+/// If more than one future produces an error, `tryx_join!` returns the error from the first future
+/// listed in the macro that produces an error.
+///
+/// The `tryx_join!` macro must be used inside of async functions, closures, and blocks.
+///
+/// # Why use `tryx_join`?
+///
+/// Consider what happens if you're wrapping a set of
+/// [`AsyncWriteExt::write_all`](tokio::io::AsyncWriteExt::write_all) operations.
+///
+/// ```
+/// use tokio::io::AsyncWriteExt;
+///
+/// # #[tokio::main(flavor = "current_thread")]
+/// # async fn main() -> anyhow::Result<()> {
+/// let temp_dir = tempfile::tempdir()?;
+/// let mut file1 = tokio::fs::File::create(temp_dir.path().join("file1")).await?;
+/// let mut file2 = tokio::fs::File::create(temp_dir.path().join("file2")).await?;
+///
+/// // With try_join, if one of the operations errors out the other one will be cancelled.
+/// tokio::try_join!(
+///     file1.write_all("data1".as_bytes()),
+///     file2.write_all("data2".as_bytes()),
+/// )?;
+///
+/// # Ok(()) }
+/// ```
+///
+/// One way to run all futures to completion is to use the [`tokio::join`] macro.
+///
+/// ```
+/// use tokio::io::AsyncWriteExt;
+///
+/// # #[tokio::main(flavor = "current_thread")]
+/// # async fn main() -> anyhow::Result<()> {
+/// let temp_dir = tempfile::tempdir()?;
+/// let mut file1 = tokio::fs::File::create(temp_dir.path().join("file1")).await?;
+/// let mut file2 = tokio::fs::File::create(temp_dir.path().join("file2")).await?;
+///
+/// // tokio_join is unaware of errors and runs all futures to completion.
+/// let (res1, res2) = tokio::join!(
+///     file1.write_all("data1".as_bytes()),
+///     file2.write_all("data2".as_bytes()),
+/// );
+///
+/// res1?;
+/// res2?;
+///
+/// # Ok(()) }
+/// ```
+///
+/// However, this is not ideal because it requires you to manually handle the results of each
+/// future. The `tryx_join` macro is a user-friendly equivalent to the above `tokio::join` example.
+///
+/// ```
+/// use tokio::io::AsyncWriteExt;
+///
+/// # #[tokio::main(flavor = "current_thread")]
+/// # async fn main() -> anyhow::Result<()> {
+/// let temp_dir = tempfile::tempdir()?;
+/// let mut file1 = tokio::fs::File::create(temp_dir.path().join("file1")).await?;
+/// let mut file2 = tokio::fs::File::create(temp_dir.path().join("file2")).await?;
+///
+/// // With tryx_join, if one of the operations errors out the other one will still be
+/// // run to completion.
+/// cancel_safe_futures::tryx_join!(
+///     file1.write_all("data1".as_bytes()),
+///     file2.write_all("data2".as_bytes()),
+/// )?;
+///
+/// # Ok(()) }
+/// ```
+///
+/// If an error occurs, the error from the first future listed in the macro that errors out will be
+/// returned. This is identical to the [`tokio::join`] example above, where `res1` is checked before
+/// `res2`.
+///
+/// # Notes
+///
+/// The supplied futures are stored inline and does not require allocating a `Vec`.
+///
+/// ### Runtime characteristics
+///
+/// By running all async expressions on the current task, the expressions are able to run
+/// **concurrently** but not in **parallel**. This means all expressions are run on the same thread
+/// and if one branch blocks the thread, all other expressions will be unable to continue. If
+/// parallelism is required, spawn each async expression using [`tokio::task::spawn`] and pass the
+/// join handle to `tryx_join!`.
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+macro_rules! tryx_join {
+    (@ {
+        // One `_` for each branch in the `tryx_join!` macro. This is not used once
+        // normalization is complete.
+        ( $($count:tt)* )
+
+        // The expression `0+1+1+ ... +1` equal to the number of branches.
+        ( $($total:tt)* )
+
+        // Normalized tryx_join! branches
+        $( ( $($skip:tt)* ) $e:expr, )*
+
+    }) => {{
+        use $crate::macros::support::{maybe_done, poll_fn, Future, Pin};
+        use $crate::macros::support::Poll::{Ready, Pending};
+
+        // Safety: nothing must be moved out of `futures`. This is to satisfy
+        // the requirement of `Pin::new_unchecked` called below.
+        //
+        // We can't use the `pin!` macro for this because `futures` is a tuple
+        // and the standard library provides no way to pin-project to the fields
+        // of a tuple.
+        let mut futures = ( $( maybe_done($e), )* );
+
+        // This assignment makes sure that the `poll_fn` closure only has a
+        // reference to the futures, instead of taking ownership of them. This
+        // mitigates the issue described in
+        // <https://internals.rust-lang.org/t/surprising-soundness-trouble-around-pollfn/17484>
+        let mut futures = &mut futures;
+
+        // Each time the future created by poll_fn is polled, a different future will be polled first
+        // to ensure every future passed to join! gets a chance to make progress even if
+        // one of the futures consumes the whole budget.
+        //
+        // This is number of futures that will be skipped in the first loop
+        // iteration the next time.
+        let mut skip_next_time: u32 = 0;
+
+        poll_fn(move |cx| {
+            const COUNT: u32 = $($total)*;
+
+            let mut is_pending = false;
+
+            let mut to_run = COUNT;
+
+            // The number of futures that will be skipped in the first loop iteration
+            let mut skip = skip_next_time;
+
+            skip_next_time = if skip + 1 == COUNT { 0 } else { skip + 1 };
+
+            // This loop runs twice and the first `skip` futures
+            // are not polled in the first iteration.
+            loop {
+            $(
+                if skip == 0 {
+                    if to_run == 0 {
+                        // Every future has been polled
+                        break;
+                    }
+                    to_run -= 1;
+
+                    // Extract the future for this branch from the tuple.
+                    let ( $($skip,)* fut, .. ) = &mut *futures;
+
+                    // Safety: future is stored on the stack above
+                    // and never moved.
+                    let mut fut = unsafe { Pin::new_unchecked(fut) };
+
+                    // Try polling
+                    if fut.as_mut().poll(cx).is_pending() {
+                        is_pending = true;
+                    }
+                } else {
+                    // Future skipped, one less future to skip in the next iteration
+                    skip -= 1;
+                }
+            )*
+            }
+
+            if is_pending {
+                Pending
+            } else {
+                Ready(Ok(($({
+                    // Extract the future for this branch from the tuple.
+                    let ( $($skip,)* fut, .. ) = &mut futures;
+
+                    // Safety: future is stored on the stack above
+                    // and never moved.
+                    let mut fut = unsafe { Pin::new_unchecked(fut) };
+
+                    let output = fut.take_output().expect("expected completed future");
+                    match output {
+                        Ok(output) => output,
+                        Err(error) => return Ready(Err(error)),
+                    }
+                },)*)))
+            }
+        }).await
+    }};
+
+    // ===== Normalize =====
+
+    (@ { ( $($s:tt)* ) ( $($n:tt)* ) $($t:tt)* } $e:expr, $($r:tt)* ) => {
+      $crate::tryx_join!(@{ ($($s)* _) ($($n)* + 1) $($t)* ($($s)*) $e, } $($r)*)
+    };
+
+    // ===== Entry point =====
+
+    ( $($e:expr),+ $(,)?) => {
+        $crate::tryx_join!(@{ () (0) } $($e,)*)
+    };
+
+    () => { async { Ok(()) }.await }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,1 +1,16 @@
+//! A "prelude" for crates using the `cancel-safe-futures` crate.
+//!
+//! This prelude is similar to the [standard library's prelude] in that you'll
+//! almost always want to import its entire contents, but unlike the
+//! standard library's prelude you'll have to do so manually:
+//!
+//! ```
+//! # #[allow(unused_imports)]
+//! use cancel_safe_futures::prelude::*;
+//! ```
+//!
+//! The prelude may grow over time as additional items see ubiquitous use.
+//!
+//! [standard library's prelude]: https://doc.rust-lang.org/std/prelude/index.html
+
 pub use crate::sink::SinkExt as _;

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -1,3 +1,5 @@
+//! Extensions for [`Sink`].
+
 mod flush_reserve;
 pub use flush_reserve::FlushReserve;
 

--- a/tests/integration_tests/macros_tryx_join.rs
+++ b/tests/integration_tests/macros_tryx_join.rs
@@ -1,0 +1,202 @@
+#![cfg(feature = "macros")]
+#![allow(clippy::disallowed_names)]
+
+use std::sync::Arc;
+use tokio::sync::{oneshot, Semaphore};
+#[cfg(not(tokio_wasm_not_wasi))]
+use tokio::test as maybe_tokio_test;
+use tokio_test::{assert_pending, assert_ready, task};
+#[cfg(tokio_wasm_not_wasi)]
+use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
+
+#[maybe_tokio_test]
+async fn sync_one_lit_expr_comma() {
+    let foo = cancel_safe_futures::tryx_join!(async { ok(1) },);
+
+    assert_eq!(foo, Ok((1,)));
+}
+
+#[maybe_tokio_test]
+async fn sync_one_lit_expr_no_comma() {
+    let foo = cancel_safe_futures::tryx_join!(async { ok(1) });
+
+    assert_eq!(foo, Ok((1,)));
+}
+
+#[maybe_tokio_test]
+async fn sync_two_lit_expr_comma() {
+    let foo = cancel_safe_futures::tryx_join!(async { ok(1) }, async { ok(2) },);
+
+    assert_eq!(foo, Ok((1, 2)));
+}
+
+#[maybe_tokio_test]
+async fn sync_two_lit_expr_no_comma() {
+    let foo = cancel_safe_futures::tryx_join!(async { ok(1) }, async { ok(2) });
+
+    assert_eq!(foo, Ok((1, 2)));
+}
+
+#[maybe_tokio_test]
+async fn two_await() {
+    let (tx1, rx1) = oneshot::channel::<&str>();
+    let (tx2, rx2) = oneshot::channel::<u32>();
+
+    let mut join = task::spawn(async { cancel_safe_futures::tryx_join!(rx1, rx2) });
+
+    assert_pending!(join.poll());
+
+    tx2.send(123).unwrap();
+    assert!(join.is_woken());
+    assert_pending!(join.poll());
+
+    tx1.send("hello").unwrap();
+    assert!(join.is_woken());
+    let res: Result<(&str, u32), _> = assert_ready!(join.poll());
+
+    assert_eq!(Ok(("hello", 123)), res);
+}
+
+#[maybe_tokio_test]
+async fn err_no_abort_early() {
+    let (tx1, rx1) = oneshot::channel::<&str>();
+    let (tx2, rx2) = oneshot::channel::<u32>();
+    let (tx3, rx3) = oneshot::channel::<&str>();
+    let (tx4, rx4) = oneshot::channel::<u32>();
+
+    let mut join = task::spawn(async {
+        cancel_safe_futures::tryx_join!(
+            async { rx1.await.map_err(|_| "rx1 failed") },
+            async { rx2.await.map_err(|_| "rx2 failed") },
+            async { rx3.await.map_err(|_| "rx3 failed") },
+            async { rx4.await.map_err(|_| "rx4 failed") },
+        )
+    });
+
+    assert_pending!(join.poll());
+
+    tx2.send(123).unwrap();
+    assert!(join.is_woken());
+    assert_pending!(join.poll());
+
+    drop(tx3);
+    assert!(join.is_woken());
+    assert_pending!(join.poll());
+
+    drop(tx1);
+    assert!(join.is_woken());
+    // The join should still be pending since tx3 and tx4 haven't completed.
+    // This is a difference from tokio::try_join.
+    assert_pending!(join.poll());
+
+    tx4.send(456).unwrap();
+    assert!(join.is_woken());
+
+    // All futures have completed.
+    let res = assert_ready!(join.poll());
+
+    // The first future listed in the tryx_join macro to produce an error is rx1. Ensure that rx1
+    // (and not rx3, which is the first future to actually cause an error) is returned here.
+    assert_eq!(res.unwrap_err(), "rx1 failed");
+}
+
+#[test]
+#[cfg(target_pointer_width = "64")]
+fn join_size() {
+    use std::mem;
+
+    let fut = async {
+        let ready = std::future::ready(ok(0i32));
+        cancel_safe_futures::tryx_join!(ready)
+    };
+    assert_eq!(mem::size_of_val(&fut), 32);
+
+    let fut = async {
+        let ready1 = std::future::ready(ok(0i32));
+        let ready2 = std::future::ready(ok(0i32));
+        cancel_safe_futures::tryx_join!(ready1, ready2)
+    };
+    assert_eq!(mem::size_of_val(&fut), 48);
+}
+
+fn ok<T>(val: T) -> Result<T, ()> {
+    Ok(val)
+}
+
+async fn non_cooperative_task(permits: Arc<Semaphore>) -> Result<usize, String> {
+    let mut exceeded_budget = 0;
+
+    for _ in 0..5 {
+        // Another task should run after this task uses its whole budget
+        for _ in 0..128 {
+            let _permit = permits.clone().acquire_owned().await.unwrap();
+        }
+
+        exceeded_budget += 1;
+    }
+
+    Ok(exceeded_budget)
+}
+
+async fn poor_little_task(permits: Arc<Semaphore>) -> Result<usize, String> {
+    let mut how_many_times_i_got_to_run = 0;
+
+    for _ in 0..5 {
+        let _permit = permits.clone().acquire_owned().await.unwrap();
+
+        how_many_times_i_got_to_run += 1;
+    }
+
+    Ok(how_many_times_i_got_to_run)
+}
+
+#[tokio::test]
+async fn try_join_does_not_allow_tasks_to_starve() {
+    let permits = Arc::new(Semaphore::new(10));
+
+    // non_cooperative_task should yield after its budget is exceeded and then poor_little_task should run.
+    let result = cancel_safe_futures::tryx_join!(
+        non_cooperative_task(Arc::clone(&permits)),
+        poor_little_task(permits)
+    );
+
+    let (non_cooperative_result, little_task_result) = result.unwrap();
+
+    assert_eq!(5, non_cooperative_result);
+    assert_eq!(5, little_task_result);
+}
+
+#[tokio::test]
+async fn a_different_future_is_polled_first_every_time_poll_fn_is_polled() {
+    let poll_order = Arc::new(std::sync::Mutex::new(vec![]));
+
+    let fut = |x, poll_order: Arc<std::sync::Mutex<Vec<i32>>>| async move {
+        for _ in 0..4 {
+            {
+                let mut guard = poll_order.lock().unwrap();
+
+                guard.push(x);
+            }
+
+            tokio::task::yield_now().await;
+        }
+    };
+
+    tokio::join!(
+        fut(1, Arc::clone(&poll_order)),
+        fut(2, Arc::clone(&poll_order)),
+        fut(3, Arc::clone(&poll_order)),
+    );
+
+    // Each time the future created by join! is polled, it should start
+    // by polling a different future first.
+    assert_eq!(
+        vec![1, 2, 3, 2, 3, 1, 3, 1, 2, 1, 2, 3],
+        *poll_order.lock().unwrap()
+    );
+}
+
+#[tokio::test]
+async fn empty_try_join() {
+    assert_eq!(cancel_safe_futures::tryx_join!() as Result<_, ()>, Ok(()));
+}

--- a/tests/integration_tests/main.rs
+++ b/tests/integration_tests/main.rs
@@ -1,0 +1,1 @@
+mod macros_tryx_join;


### PR DESCRIPTION
Adapt `try_join` from Tokio to poll all futures to completion rather than immediately returning an error if one future fails.