### PR TITLE
add a cancel-safe RobustMutex

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: cargo xfmt --check
       - name: Run rustdoc
         env:
-          RUSTC_BOOTSTRAP: 1  # for feature(doc_cfg)
+          RUSTC_BOOTSTRAP: 1 # for feature(doc_cfg)
           RUSTDOCFLAGS: -Dwarnings --cfg doc_cfg
         run: cargo doc --all-features --workspace
       - name: Check for differences
@@ -37,8 +37,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
-        rust-version: [ "1.64", stable ]
+        os: [ubuntu-latest]
+        rust-version: ["1.64", stable]
       fail-fast: false
     env:
       RUSTFLAGS: -D warnings
@@ -58,6 +58,42 @@ jobs:
         if: matrix.rust-version == 'stable'
         run: ./scripts/commands.sh doctest
 
+  miri:
+    name: Miri
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust-version: [nightly]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust-version }}
+          components: miri
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@nextest
+      - name: Run miri
+        run: ./scripts/commands.sh miri
+
+  coverage:
+    name: Collect coverage
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust-version: [stable]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust-version }}
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@nextest
+      - name: Run coverage
+        run: ./scripts/commands.sh coverage
+
   no-std:
     name: Build no_std for ${{ matrix.target }}
     runs-on: ubuntu-latest
@@ -68,7 +104,7 @@ jobs:
         target:
           - thumbv7m-none-eabi
           - thumbv6m-none-eabi
-        rust-version: [ stable ]
+        rust-version: [stable]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -77,5 +113,5 @@ jobs:
           toolchain: ${{ matrix.rust-version }}
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@cargo-hack    
+      - uses: taiki-e/install-action@cargo-hack
       - run: ./scripts/commands.sh build-no-std --target ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Run coverage
         run: ./scripts/commands.sh coverage
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,7 @@ rustdoc-args = ["--cfg=doc_cfg"]
 [dependencies]
 futures-core = { version = "0.3.28", default-features = false }
 futures-sink = { version = "0.3.28", default-features = false }
-futures-util = { version = "0.3.28", default-features = false, features = [
-    "sink",
-] }
+futures-util = { version = "0.3.28", default-features = false, features = ["sink"] }
 tokio = { version = "1.28.2", features = ["sync"], optional = true }
 futures = { version = "0.3.28", optional = true }
 pin-project-lite = "0.2.9"
@@ -33,35 +31,15 @@ async-stream = "0.3.5"
 bytes = "1.4.0"
 debug-ignore = "1.0.5"
 tempfile = "3.6.0"
-tokio = { version = "1.28.2", features = [
-    "fs",
-    "io-util",
-    "macros",
-    "rt",
-    "rt-multi-thread",
-    "sync",
-    "time",
-] }
+tokio = { version = "1.28.2", features = ["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync", "time"] }
 tokio-test = "0.4.0"
 
 [features]
 default = ["std", "macros"]
-std = [
-    "alloc",
-    "futures-core/std",
-    "futures-sink/std",
-    "futures-util/std",
-    "dep:tokio",
-]
+std = ["alloc", "futures-core/std", "futures-sink/std", "futures-util/std", "dep:tokio"]
 alloc = ["futures-core/alloc", "futures-sink/alloc", "futures-util/alloc"]
 parking_lot = ["tokio?/parking_lot"]
 macros = []
 
 # Internal-only feature, used for documentation and doctests. Not part of the public API.
-internal-docs = [
-    "dep:futures",
-    "dep:tokio",
-    "tokio?/io-util",
-    "tokio?/macros",
-    "tokio?/rt",
-]
+internal-docs = ["dep:futures", "dep:tokio", "tokio?/io-util", "tokio?/macros", "tokio?/rt"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tokio-test = "0.4.0"
 default = ["std", "macros"]
 std = ["alloc", "futures-core/std", "futures-sink/std", "futures-util/std", "dep:tokio"]
 alloc = ["futures-core/alloc", "futures-sink/alloc", "futures-util/alloc"]
+parking_lot = ["tokio?/parking_lot"]
 macros = []
 
 # Internal-only feature, used for documentation and doctests. Not part of the public API.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,9 @@ rustdoc-args = ["--cfg=doc_cfg"]
 [dependencies]
 futures-core = { version = "0.3.28", default-features = false }
 futures-sink = { version = "0.3.28", default-features = false }
-futures-util = { version = "0.3.28", default-features = false, features = ["sink"] }
+futures-util = { version = "0.3.28", default-features = false, features = [
+    "sink",
+] }
 tokio = { version = "1.28.2", features = ["sync"], optional = true }
 futures = { version = "0.3.28", optional = true }
 pin-project-lite = "0.2.9"
@@ -31,15 +33,35 @@ async-stream = "0.3.5"
 bytes = "1.4.0"
 debug-ignore = "1.0.5"
 tempfile = "3.6.0"
-tokio = { version = "1.28.2", features = ["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.28.2", features = [
+    "fs",
+    "io-util",
+    "macros",
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
 tokio-test = "0.4.0"
 
 [features]
 default = ["std", "macros"]
-std = ["alloc", "futures-core/std", "futures-sink/std", "futures-util/std", "dep:tokio"]
+std = [
+    "alloc",
+    "futures-core/std",
+    "futures-sink/std",
+    "futures-util/std",
+    "dep:tokio",
+]
 alloc = ["futures-core/alloc", "futures-sink/alloc", "futures-util/alloc"]
 parking_lot = ["tokio?/parking_lot"]
 macros = []
 
 # Internal-only feature, used for documentation and doctests. Not part of the public API.
-internal-docs = ["dep:futures", "dep:tokio", "tokio?/io-util", "tokio?/macros", "tokio?/rt", "tokio?/rt-multi-thread"]
+internal-docs = [
+    "dep:futures",
+    "dep:tokio",
+    "tokio?/io-util",
+    "tokio?/macros",
+    "tokio?/rt",
+]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Alternative futures adapters that are more cancellation-aware.
 
 This crate solves a few related but distinct problems:
 
-### Cancel-safe futures adapters
+### 1. Cancel-safe futures adapters
 
 The [`futures`](https://docs.rs/futures/latest/futures/) library contains many adapters that
 make writing asynchronous Rust code more pleasant. However, some of those combinators make it
@@ -57,7 +57,7 @@ while item.is_some() {
 
 ```
 
-### `then_try` adapters that don't perform cancellations
+### 2. `then_try` adapters that don't perform cancellations
 
 The futures and tokio libraries come with a number of `try_` adapters and macros, for example
 `tokio::try_join!`. These adapters have the property that if one of the futures under
@@ -80,7 +80,15 @@ The `then_try` family includes:
 
 For a detailed example, see the documentation for the `join_then_try` macro.
 
-### Cooperative cancellation
+### 3. Cancel-safe mutexes
+
+The `tokio::sync::Mutex` shipped with Tokio has resulted in many bugs in practice,
+particularly around cancellations.
+
+This crate provides an alternative mutex, `sync::Mutex`, that does not have those pitfalls.
+For more, see the documentation for `sync::Mutex`.
+
+### 4. Cooperative cancellation
 
 Executors like Tokio support forcible cancellation for async tasks via facilities like
 `tokio::task::JoinHandle::abort`. However, this can cause cancellations at any arbitrary await
@@ -106,6 +114,7 @@ an adapter that is not yet implemented, please open an issue or a pull request.
 * `std` (enabled by default): Enables items that depend on `std`, including items that depend on
   `alloc`.
 * `alloc` (enabled by default): Enables items that depend on `alloc`.
+* `parking_lot`: Switches to `parking_lot`'s mutexes.
 
 No-std users must turn off default features while importing this crate.
 

--- a/scripts/commands.sh
+++ b/scripts/commands.sh
@@ -40,15 +40,7 @@ run_miri() {
     run_cargo_std miri nextest run --all-targets -j2
 }
 
-run_coverage() {
-    echo_err "Running coverage"
-    run_cargo_std llvm-cov nextest --all-targets
-}
-
 run_doctest() {
-    echo_err "Running doctests"
-    cargo test --doc
-
     echo_err "Running doctests with all features"
     cargo test --all-features --doc
 }
@@ -115,7 +107,6 @@ while [[ "$#" -gt 0 ]]; do
         miri) run_miri ;;
         coverage) run_coverage ;;
         dt|doctest) run_doctest ;;
-        coverage) run_coverage ;;
         build-no-std)
             shift;
             case $1 in

--- a/scripts/commands.sh
+++ b/scripts/commands.sh
@@ -35,6 +35,16 @@ run_nextest() {
     run_cargo_hack nextest run --all-targets
 }
 
+run_miri() {
+    echo_err "Running miri"
+    run_cargo_std miri nextest run --all-targets -j2
+}
+
+run_coverage() {
+    echo_err "Running coverage"
+    run_cargo_std llvm-cov nextest --all-targets
+}
+
 run_doctest() {
     echo_err "Running doctests"
     cargo test --doc
@@ -72,6 +82,10 @@ run_cargo_hack() {
     $CARGO hack --feature-powerset --exclude-features "$joined_excluded_features" "$@"
 }
 
+run_cargo_std() {
+    $CARGO "$@" --features std
+}
+
 run_cargo_hack_no_std() {
     joined_excluded_features=$(printf ",%s" "${EXCLUDED_FEATURES_NO_STD[@]}")
     # Strip leading comma
@@ -81,7 +95,7 @@ run_cargo_hack_no_std() {
 }
 
 if [[ $# -eq 0 ]]; then
-    echo_err "Usage: commands.sh [b|build|t|test|nt|nextest|dt|doctest|build-no-std]"
+    echo_err "Usage: commands.sh [b|build|t|test|nt|nextest|miri|coverage|dt|doctest|build-no-std]"
     exit 1
 fi
 
@@ -91,6 +105,8 @@ while [[ "$#" -gt 0 ]]; do
         b|build) run_build ;;
         t|test) run_test ;;
         nt|nextest) run_nextest ;;
+        miri) run_miri ;;
+        coverage) run_coverage ;;
         dt|doctest) run_doctest ;;
         build-no-std)
             shift;
@@ -105,7 +121,7 @@ while [[ "$#" -gt 0 ]]; do
             fi
 
             run_build_no_std "$build_target" ;;
-        -h|--help) echo "Usage: commands.sh [b|build|t|test|test-no-std]"; exit 0 ;;
+        -h|--help) echo "Usage: commands.sh [b|build|t|test|nt|nextest|miri|coverage|dt|doctest|build-no-std]"; exit 0 ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift

--- a/scripts/commands.sh
+++ b/scripts/commands.sh
@@ -47,8 +47,8 @@ run_doctest() {
 
 run_coverage() {
     echo_err "Running coverage (requires nightly)"
-    run_cargo_std llvm-cov nextest --all-targets --lcov --output-path lcov.info
-    run_cargo_std llvm-cov test --doc --lcov --output-path lcov-doctest.info
+    run_cargo_std llvm-cov nextest --all-features --all-targets --lcov --output-path lcov.info
+    run_cargo_std llvm-cov test --all-features --doc --lcov --output-path lcov-doctest.info
     echo_err "Wrote output to lcov.info and lcov-doctest.info"
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,8 +85,8 @@
 //! The [`tokio::sync::Mutex`] shipped with Tokio has resulted in many bugs in practice,
 //! particularly around cancellations.
 //!
-//! This crate provides an alternative mutex, [`sync::Mutex`], that does not have those pitfalls.
-//! For more, see the documentation for [`sync::Mutex`].
+//! This crate provides an alternative mutex API, called [`CMutex`](sync::CMutex), that does not
+//! have those pitfalls. For more, see the documentation for [`CMutex`](sync::CMutex).
 //!
 //! ## 4. Cooperative cancellation
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,8 +85,8 @@
 //! The [`tokio::sync::Mutex`] shipped with Tokio has resulted in many bugs in practice,
 //! particularly around cancellations.
 //!
-//! This crate provides an alternative mutex API, called [`CMutex`](sync::CMutex), that does not
-//! have those pitfalls. For more, see the documentation for [`CMutex`](sync::CMutex).
+//! This crate provides an alternative mutex API, called [`RobustMutex`](sync::RobustMutex), that does not
+//! have those pitfalls. For more, see the documentation for [`RobustMutex`](sync::RobustMutex).
 //!
 //! ## 4. Cooperative cancellation
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! This crate solves a few related but distinct problems:
 //!
-//! ## Cancel-safe futures adapters
+//! ## 1. Cancel-safe futures adapters
 //!
 //! The [`futures`](https://docs.rs/futures/latest/futures/) library contains many adapters that
 //! make writing asynchronous Rust code more pleasant. However, some of those combinators make it
@@ -57,7 +57,7 @@
 //! # Ok(()) }
 //! ```
 //!
-//! ## `then_try` adapters that don't perform cancellations
+//! ## 2. `then_try` adapters that don't perform cancellations
 //!
 //! The futures and tokio libraries come with a number of `try_` adapters and macros, for example
 //! [`tokio::try_join!`]. These adapters have the property that if one of the futures under
@@ -80,7 +80,15 @@
 //!
 //! For a detailed example, see the documentation for the [`join_then_try`] macro.
 //!
-//! ## Cooperative cancellation
+//! ## 3. Cancel-safe mutexes
+//!
+//! The [`tokio::sync::Mutex`] shipped with Tokio has resulted in many bugs in practice,
+//! particularly around cancellations.
+//!
+//! This crate provides an alternative mutex, [`sync::Mutex`], that does not have those pitfalls.
+//! For more, see the documentation for [`sync::Mutex`].
+//!
+//! ## 4. Cooperative cancellation
 //!
 //! Executors like Tokio support forcible cancellation for async tasks via facilities like
 //! [`tokio::task::JoinHandle::abort`]. However, this can cause cancellations at any arbitrary await
@@ -106,6 +114,7 @@
 //! * `std` (enabled by default): Enables items that depend on `std`, including items that depend on
 //!   `alloc`.
 //! * `alloc` (enabled by default): Enables items that depend on `alloc`.
+//! * `parking_lot`: Switches to `parking_lot`'s mutexes.
 //!
 //! No-std users must turn off default features while importing this crate.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 //! Alternative futures adapters that are more cancellation-aware.
 //!
@@ -130,6 +130,7 @@ pub mod prelude;
 pub mod sink;
 pub mod stream;
 mod support;
+pub mod sync;
 
 pub use sink::SinkExt;
 pub use stream::TryStreamExt;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -11,3 +11,5 @@ mod poison;
 
 #[cfg(feature = "std")]
 pub use mutex::*;
+#[cfg(feature = "std")]
+pub use poison::{LockResult, PoisonError, TryLockError, TryLockResult};

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,0 +1,7 @@
+#[cfg(feature = "std")]
+mod mutex;
+#[cfg(feature = "std")]
+mod poison;
+
+#[cfg(feature = "std")]
+pub use mutex::*;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,8 +1,8 @@
 //! Alternative synchronization primitives that are more cancellation-aware.
 //!
-//! Currently, this crate contains [`CMutex`], which is a variant on an async mutex that is more
+//! Currently, this crate contains [`RobustMutex`], which is a variant on an async mutex that is more
 //! cancel-safe. For more about how this differs from [`tokio::sync::Mutex`], see the documentation
-//! for [`CMutex`].
+//! for [`RobustMutex`].
 
 #[cfg(feature = "std")]
 mod mutex;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,7 +1,8 @@
 //! Alternative synchronization primitives that are more cancellation-aware.
 //!
-//! Currently, this crate contains a [`Mutex`] implementation that is more cancellation-aware. For
-//! more about how this differs from [`tokio::sync::Mutex`], see the documentation for [`Mutex`].
+//! Currently, this crate contains [`CMutex`], which is a variant on an async mutex that is more
+//! cancel-safe. For more about how this differs from [`tokio::sync::Mutex`], see the documentation
+//! for [`CMutex`].
 
 #[cfg(feature = "std")]
 mod mutex;

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -1,0 +1,149 @@
+use std::fmt;
+use std::ops::{Deref, DerefMut};
+use std::sync::{LockResult, TryLockError, TryLockResult};
+
+use super::poison;
+use futures_core::Future;
+use tokio::sync::MutexGuard;
+
+pub struct Mutex<T> {
+    inner: tokio::sync::Mutex<T>,
+    poison: poison::Flag,
+}
+
+impl<T> Mutex<T> {
+    pub fn new(value: T) -> Self {
+        Self {
+            inner: tokio::sync::Mutex::new(value),
+            poison: poison::Flag::new(),
+        }
+    }
+
+    pub fn lock(&self) -> LockResult<impl Future<Output = ActionPermit<'_, T>>> {
+        ActionPermit::new(self)
+    }
+
+    pub fn try_lock(&self) -> TryLockResult<ActionPermit<'_, T>> {
+        match self.inner.try_lock() {
+            Ok(guard) => {
+                ActionPermit::from_guard(&self.poison, guard).map_err(TryLockError::Poisoned)
+            }
+            Err(_) => Err(TryLockError::WouldBlock),
+        }
+    }
+
+    /// Determines whether the mutex is poisoned.
+    ///
+    /// If another thread is active, the mutex can still become poisoned at any
+    /// time. You should not trust a `false` value for program correctness
+    /// without additional synchronization.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cancel_safe_futures::sync::Mutex;
+    /// use std::sync::Arc;
+    /// use std::thread;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    ///
+    /// let mutex = Arc::new(Mutex::new(0));
+    /// let c_mutex = Arc::clone(&mutex);
+    ///
+    /// let _ = tokio::task::spawn(async move {
+    ///     let _lock = c_mutex.lock().unwrap().await;
+    ///     panic!(); // the mutex gets poisoned
+    /// }).await;
+    /// assert_eq!(mutex.is_poisoned(), true);
+    /// # }
+    /// ```
+    pub fn is_poisoned(&self) -> bool {
+        self.poison.get()
+    }
+
+    pub fn into_inner(self) -> LockResult<T>
+    where
+        T: Sized,
+    {
+        let data = self.inner.into_inner();
+        poison::map_result(self.poison.borrow(), |()| data)
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Mutex<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut d = f.debug_struct("Mutex");
+        match self.try_lock() {
+            Ok(inner) => d.field("data", &*inner.guard),
+            Err(_) => d.field("data", &format_args!("<locked>")),
+        };
+        d.field("poisoned", &self.poison.get());
+        d.finish()
+    }
+}
+
+/// A token that grants the ability to run one closure against the data guarded
+/// by a [`Mutex`].
+///
+/// This is produced by the `lock` family of operations on [`Mutex`] and is
+/// intended to provide a more robust API than the traditional "smart pointer"
+/// mutex guard.
+pub struct ActionPermit<'a, T: ?Sized> {
+    guard: MutexGuard<'a, T>,
+    poison: &'a poison::Flag,
+    poison_guard: poison::Guard,
+}
+
+impl<'a, T> ActionPermit<'a, T> {
+    pub(crate) fn new(
+        mutex: &'a Mutex<T>,
+    ) -> LockResult<impl Future<Output = ActionPermit<'a, T>>> {
+        poison::map_result(mutex.poison.guard(), |poison_guard| async {
+            let guard = mutex.inner.lock().await;
+            Self {
+                guard,
+                poison: &mutex.poison,
+                poison_guard,
+            }
+        })
+    }
+
+    pub(crate) fn from_guard(
+        poison: &'a poison::Flag,
+        guard: MutexGuard<'a, T>,
+    ) -> LockResult<Self> {
+        poison::map_result(poison.guard(), |poison_guard| Self {
+            guard,
+            poison,
+            poison_guard,
+        })
+    }
+
+    /// Runs a closure with access to the guarded data, consuming the permit in
+    /// the process.
+    pub fn perform<R>(mut self, action: impl FnOnce(&mut T) -> R) -> R {
+        action(&mut *self.guard)
+
+        // Note: we're relying on the Drop impl for `self` to unlock the mutex.
+    }
+}
+
+impl<T: ?Sized> Drop for ActionPermit<'_, T> {
+    #[inline]
+    fn drop(&mut self) {
+        self.poison.done(&self.poison_guard);
+    }
+}
+
+impl<T: ?Sized + fmt::Debug> fmt::Debug for ActionPermit<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&*self.guard, f)
+    }
+}
+
+impl<T: ?Sized + fmt::Display> fmt::Display for ActionPermit<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&*self, f)
+    }
+}

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -398,7 +398,9 @@ impl<T: ?Sized> RobustMutex<T> {
     ///         *n = 1;
     ///     }.boxed());
     ///     tokio::select! {
-    ///         _ = fut => {}
+    ///         _ = fut => {
+    ///             panic!("this branch should not be encountered");
+    ///         }
     ///         _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {
     ///             // Exit the task, causing `fut` to be cancelled after 100ms.
     ///         }

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -71,6 +71,10 @@ use tokio::sync::MutexGuard;
 ///
 ///   This is the problem that *cancel safety* solves.
 ///
+/// Both of these problems can also be solved in an ad-hoc manner (for example, by carefully
+/// checking for and restoring invariants at the start of each critical section). However, the goal
+/// of this mutex is to provide a systematic, if conservative, solution to these problems.
+///
 /// # Panic safety with poisoning
 ///
 /// Like [`std::sync::Mutex`] but *unlike* [`tokio::sync::Mutex`], this mutex implements a strategy

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -194,7 +194,7 @@ impl<T: ?Sized> CMutex<T> {
         ActionPermit::new(guard, &self.poison)
     }
 
-    /// Blockingly locks this `Mutex`. When the lock has been acquired, function returns a
+    /// Blockingly locks this `Mutex`. When the lock has been acquired, the function returns a
     /// [`ActionPermit`].
     ///
     /// This method is intended for use cases where you need to use this mutex in asynchronous code
@@ -244,7 +244,7 @@ impl<T: ?Sized> CMutex<T> {
         ActionPermit::new(guard, &self.poison)
     }
 
-    /// Attempts to acquire the lock.
+    /// Attempts to acquire the lock, returning an [`ActionPermit`] if successful.
     ///
     /// # Errors
     ///
@@ -386,10 +386,16 @@ impl<'a, T: ?Sized> ActionPermit<'a, T> {
         })
     }
 
-    /// Runs a closure with access to the guarded data, consuming the permit in the process.
+    /// Runs a closure with access to the guarded data, consuming the permit in the process and
+    /// unlocking the mutex once the closure completes.
     ///
     /// This is a synchronous closure, which means that it cannot have await points within it. This
     /// guarantees cancel safety for this mutex.
+    ///
+    /// # Notes
+    ///
+    /// `action` is *not* run inside a synchronous context. This means that operations like
+    /// [`tokio::sync::mpsc::Sender::blocking_send`] will panic inside `action`.
     ///
     /// # Examples
     ///

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -301,12 +301,10 @@ impl<T: ?Sized> Mutex<T> {
     /// ```
     /// use cancel_safe_futures::sync::Mutex;
     ///
-    /// fn main() {
-    ///     let mut mutex = Mutex::new(1);
+    /// let mut mutex = Mutex::new(1);
     ///
-    ///     let n = mutex.get_mut();
-    ///     *n = 2;
-    /// }
+    /// let n = mutex.get_mut();
+    /// *n = 2;
     /// ```
     pub fn get_mut(&mut self) -> &mut T {
         self.inner.get_mut()

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -70,14 +70,15 @@ use tokio::sync::MutexGuard;
 ///   This is the problem that *cancel safety* solves.
 ///
 /// Both of these problems can also be solved in an ad-hoc manner (for example, by carefully
-/// checking for and restoring invariants at the start of each critical section). However, **the goal
-/// of this mutex is to provide a systematic, if conservative, solution to these problems.**
+/// checking for and restoring invariants at the start of each critical section). However, **the
+/// goal of this mutex is to provide a systematic, if conservative, solution to these problems.**
 ///
 /// # Panic safety
 ///
 /// Like [`std::sync::Mutex`] but *unlike* [`tokio::sync::Mutex`], this mutex implements a strategy
-/// called "poisoning" where a mutex is considered poisoned whenever a task panics while holding the
-/// mutex. Once a mutex is poisoned, all other tasks are unable to access the data by default.
+/// called "poisoning" where a mutex is considered poisoned whenever a task panics within one of the
+/// [`ActionPermit`] perform methods. Once a mutex is poisoned, all other tasks are unable to access
+/// the data by default.
 ///
 /// This means that the [`lock`](Self::lock) and [`try_lock`](Self::try_lock) methods return a
 /// [`Result`] which indicates whether a mutex has been poisoned or not. Most usage of a mutex will

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -14,13 +14,12 @@ use tokio::sync::MutexGuard;
 /// # The basic idea
 ///
 /// A mutex is a synchronization structure which allows only one task to access some data at a time.
-/// The general idea behind a mutex is that the data it owns has some *invariants*.
+/// The general idea behind a mutex is that the data it owns has some *invariants*. When a task
+/// acquires a lock on the mutex, it enters a *critical section*. Within this critical section, the
+/// invariants can temporarily be violated. It is expected that the task will restore those
+/// invariants before releasing the lock.
 ///
-/// When a task acquires a lock on the mutex, it enters a *critical section*. Within this critical
-/// section, the invariants can temporarily be *violated*. It is expected that the task will restore
-/// those invariants before releasing the lock.
-///
-/// For example, let's say that we have a mutex which guards two `HashMap`s. The invariants of this
+/// For example, let's say that we have a mutex which guards two `HashMap`s, with the invariant that
 /// mutex are that the two `HashMap`s always contain the same keys. With a Tokio mutex, you might
 /// write something like:
 ///

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -96,6 +96,13 @@ use tokio::sync::MutexGuard;
 /// by returning [`ActionPermit`] instances which only provide access to the guarded data within a
 /// synchronous closure, as opposed to the RAII style that [`std::sync::MutexGuard`] and
 /// [`tokio::sync::MutexGuard`] use.
+///
+/// # Features
+///
+/// Basic mutex operations are supported. In the future, this will support:
+///
+/// - An `OwnedActionPermit`, similar to [`tokio::sync::OwnedMutexGuard`].
+/// - A `MappedActionPermit`, similar to [`tokio::sync::MappedMutexGuard`].
 pub struct Mutex<T: ?Sized> {
     poison: poison::Flag,
     inner: tokio::sync::Mutex<T>,
@@ -188,11 +195,6 @@ impl<T: ?Sized> Mutex<T> {
     /// # Panics
     ///
     /// This function panics if called within an asynchronous execution context.
-    ///
-    ///   - If you find yourself in an asynchronous execution context and needing to call some
-    ///     (synchronous) function which performs one of these `blocking_` operations, then consider
-    ///     wrapping that call inside [`spawn_blocking()`][tokio::runtime::Handle::spawn_blocking]
-    ///     (or [`block_in_place()`][tokio::task::block_in_place]).
     ///
     /// # Examples
     ///

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -427,7 +427,8 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for RobustMutex<T> {
 /// with a hypothetical `lock_and_perform` function. Let's say we use it in a `select!` statement
 /// thus:
 ///
-/// ```rust
+/// ```rust,no_run
+/// use std::sync::LockResult;
 /// use std::time::Duration;
 /// use tokio::time::sleep;
 ///
@@ -437,6 +438,10 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for RobustMutex<T> {
 /// # struct MyMutex<T> { _marker: std::marker::PhantomData<T> }
 ///
 /// impl<T> MyMutex<T> {
+///     fn new(data: T) -> Self {
+///         /* ... */
+///         todo!();
+///     }
 ///     async fn lock_and_perform<U>(self, action: impl FnOnce(&mut T) -> U) -> LockResult<U> {
 ///         /* ... */
 /// #       todo!()
@@ -468,9 +473,10 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for RobustMutex<T> {
 /// ```
 ///
 /// Then, if `sleep` fires before `fut`, the non-cloneable type is dropped without being used. This
-/// leads to cancel unsafety, in a way very similar to the cancel unsafety that
-/// [`futures::SinkExt::send`] has, and that this crate's
-/// [`SinkExt::reserve`](crate::SinkExt::reserve) solves.
+/// leads to cancel unsafety.
+///
+/// This is very similar to the cancel unsafety that [`futures::SinkExt::send`] has, and that this
+/// crate's [`SinkExt::reserve`](crate::SinkExt::reserve) solves.
 #[clippy::has_significant_drop]
 pub struct ActionPermit<'a, T: ?Sized> {
     poison: &'a poison::Flag,

--- a/src/sync/poison.rs
+++ b/src/sync/poison.rs
@@ -11,16 +11,14 @@ pub struct Flag {
     failed: AtomicBool,
 }
 
-// Note that the Ordering uses to access the `failed` field of `Flag` below is
-// always `Relaxed`, and that's because this isn't actually protecting any data,
-// it's just a flag whether we've panicked or not.
+// Note that the Ordering uses to access the `failed` field of `Flag` below is always `Relaxed`, and
+// that's because this isn't actually protecting any data, it's just a flag whether we've panicked
+// or not.
 //
-// The actual location that this matters is when a mutex is **locked** which is
-// where we have external synchronization ensuring that we see memory
-// reads/writes to this flag.
+// The actual location that this matters is when a mutex is **locked** which is where we have
+// external synchronization ensuring that we see memory reads/writes to this flag.
 //
-// As a result, if it matters, we should see the correct value for `failed` in
-// all cases.
+// As a result, if it matters, we should see the correct value for `failed` in all cases.
 
 impl Flag {
     #[inline]
@@ -77,16 +75,5 @@ where
     match result {
         Ok(t) => Ok(f(t)),
         Err(error) => Err(PoisonError::new(f(error.into_inner()))),
-    }
-}
-
-pub async fn map_result_async<T, U, F, Fut>(result: LockResult<T>, f: F) -> LockResult<U>
-where
-    F: FnOnce(T) -> Fut,
-    Fut: Future<Output = U>,
-{
-    match result {
-        Ok(t) => Ok(f(t).await),
-        Err(error) => Err(PoisonError::new(f(error.into_inner()).await)),
     }
 }

--- a/src/sync/poison.rs
+++ b/src/sync/poison.rs
@@ -1,3 +1,7 @@
+// This file is adapted from
+// https://github.com/rust-lang/rust/blob/475c71da0710fd1d40c046f9cee04b733b5b2b51/library/std/src/sync/poison.rs
+// and is used under the MIT and Apache 2.0 licenses.
+
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::{
     sync::{LockResult, PoisonError},

--- a/src/sync/poison.rs
+++ b/src/sync/poison.rs
@@ -5,11 +5,11 @@
 use core::sync::atomic::{AtomicU8, Ordering};
 use std::{error, fmt, thread};
 
-/// A type of error which can be returned whenever a lock is acquired.
+/// A type of error which can be returned whenever a [`RobustMutex`] is acquired.
 ///
-/// [`RobustMutex`]es poisoned whenever a thread panics or a cancellation happens while the lock is
-/// held. The precise semantics for when a lock is poisoned is documented on each lock, but once a
-/// lock is poisoned then all future acquisitions will return this error.
+/// [`RobustMutex`]es are poisoned whenever a thread panics or a cancellation happens while the lock
+/// is held. The precise semantics for when a lock is poisoned is documented on [`RobustMutex`], but
+/// once a lock is poisoned then all future acquisitions will return this error.
 ///
 /// [`RobustMutex`]: crate::sync::RobustMutex
 pub struct PoisonError<T> {

--- a/src/sync/poison.rs
+++ b/src/sync/poison.rs
@@ -1,0 +1,92 @@
+use core::sync::atomic::{AtomicBool, Ordering};
+use std::{
+    sync::{LockResult, PoisonError},
+    thread,
+};
+
+use futures_core::Future;
+
+#[derive(Debug)]
+pub struct Flag {
+    failed: AtomicBool,
+}
+
+// Note that the Ordering uses to access the `failed` field of `Flag` below is
+// always `Relaxed`, and that's because this isn't actually protecting any data,
+// it's just a flag whether we've panicked or not.
+//
+// The actual location that this matters is when a mutex is **locked** which is
+// where we have external synchronization ensuring that we see memory
+// reads/writes to this flag.
+//
+// As a result, if it matters, we should see the correct value for `failed` in
+// all cases.
+
+impl Flag {
+    #[inline]
+    pub const fn new() -> Flag {
+        Flag {
+            failed: AtomicBool::new(false),
+        }
+    }
+
+    /// Check the flag for an unguarded borrow, where we only care about existing poison.
+    #[inline]
+    pub fn borrow(&self) -> LockResult<()> {
+        if self.get() {
+            Err(PoisonError::new(()))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Check the flag for a guarded borrow, where we may also set poison when `done`.
+    #[inline]
+    pub fn guard(&self) -> LockResult<Guard> {
+        let ret = Guard {
+            panicking: thread::panicking(),
+        };
+        if self.get() {
+            Err(PoisonError::new(ret))
+        } else {
+            Ok(ret)
+        }
+    }
+
+    #[inline]
+    pub fn done(&self, guard: &Guard) {
+        if !guard.panicking && thread::panicking() {
+            self.failed.store(true, Ordering::Relaxed);
+        }
+    }
+
+    #[inline]
+    pub fn get(&self) -> bool {
+        self.failed.load(Ordering::Relaxed)
+    }
+}
+
+pub struct Guard {
+    panicking: bool,
+}
+
+pub fn map_result<T, U, F>(result: LockResult<T>, f: F) -> LockResult<U>
+where
+    F: FnOnce(T) -> U,
+{
+    match result {
+        Ok(t) => Ok(f(t)),
+        Err(error) => Err(PoisonError::new(f(error.into_inner()))),
+    }
+}
+
+pub async fn map_result_async<T, U, F, Fut>(result: LockResult<T>, f: F) -> LockResult<U>
+where
+    F: FnOnce(T) -> Fut,
+    Fut: Future<Output = U>,
+{
+    match result {
+        Ok(t) => Ok(f(t).await),
+        Err(error) => Err(PoisonError::new(f(error.into_inner()).await)),
+    }
+}

--- a/src/sync/poison.rs
+++ b/src/sync/poison.rs
@@ -62,7 +62,7 @@ impl<T> fmt::Debug for PoisonError<T> {
 
 impl<T> fmt::Display for PoisonError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "poisoned lock: {:?}", DebugFlags(self.flags))
+        write!(f, "poisoned lock {:?}", DebugFlags(self.flags))
     }
 }
 
@@ -236,7 +236,7 @@ impl fmt::Debug for DebugFlags {
                 poisoned_by.push("panic");
             }
             if self.0 & CANCEL_POISON != 0 {
-                poisoned_by.push("cancellation");
+                poisoned_by.push("async cancellation");
             }
 
             write!(f, "(poisoned by {})", poisoned_by.join(", "))

--- a/src/sync/poison.rs
+++ b/src/sync/poison.rs
@@ -2,15 +2,156 @@
 // https://github.com/rust-lang/rust/blob/475c71da0710fd1d40c046f9cee04b733b5b2b51/library/std/src/sync/poison.rs
 // and is used under the MIT and Apache 2.0 licenses.
 
-use core::sync::atomic::{AtomicBool, Ordering};
-use std::{
-    sync::{LockResult, PoisonError},
-    thread,
-};
+use core::sync::atomic::{AtomicU8, Ordering};
+use std::{error, fmt, thread};
 
-#[derive(Debug)]
+/// A type of error which can be returned whenever a lock is acquired.
+///
+/// [`RobustMutex`]es poisoned whenever a thread panics or a cancellation happens while the lock is
+/// held. The precise semantics for when a lock is poisoned is documented on each lock, but once a
+/// lock is poisoned then all future acquisitions will return this error.
+///
+/// [`RobustMutex`]: crate::sync::RobustMutex
+pub struct PoisonError<T> {
+    guard: T,
+    flags: u8,
+}
+
+impl<T> PoisonError<T> {
+    fn new(guard: T, flags: u8) -> PoisonError<T> {
+        PoisonError { guard, flags }
+    }
+
+    /// Returns true if this error indicates that the lock was poisoned by a
+    /// panic from another task.
+    pub fn is_panic(&self) -> bool {
+        self.flags & PANIC_POISON != 0
+    }
+
+    /// Returns true if this error indicates that the lock was poisoned by an early cancellation.
+    pub fn is_cancel(&self) -> bool {
+        self.flags & CANCEL_POISON != 0
+    }
+
+    /// Consumes this error indicating that a lock is poisoned, returning the
+    /// underlying guard to allow access regardless.
+    pub fn into_inner(self) -> T {
+        self.guard
+    }
+
+    /// Reaches into this error indicating that a lock is poisoned, returning a
+    /// reference to the underlying guard to allow access regardless.
+    pub fn get_ref(&self) -> &T {
+        &self.guard
+    }
+
+    /// Reaches into this error indicating that a lock is poisoned, returning a
+    /// mutable reference to the underlying guard to allow access regardless.
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.guard
+    }
+}
+
+impl<T> fmt::Debug for PoisonError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PoisonError")
+            .field("flags", &DebugFlags(self.flags))
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T> fmt::Display for PoisonError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "poisoned lock: {:?}", DebugFlags(self.flags))
+    }
+}
+
+impl<T> error::Error for PoisonError<T> {}
+
+/// An enumeration of possible errors associated with a [`TryLockResult`] which
+/// can occur while trying to acquire a lock, from the [`try_lock`] method on a
+/// [`RobustMutex`].
+///
+/// [`try_lock`]: crate::sync::RobustMutex::try_lock
+/// [`RobustMutex`]: crate::sync::RobustMutex
+pub enum TryLockError<T> {
+    /// The lock could not be acquired because another task failed while holding
+    /// the lock, or an early cancellation occurred.
+    Poisoned(PoisonError<T>),
+
+    /// The lock could not be acquired at this time because the operation would
+    /// otherwise block.
+    WouldBlock,
+}
+
+impl<T> From<PoisonError<T>> for TryLockError<T> {
+    fn from(error: PoisonError<T>) -> TryLockError<T> {
+        TryLockError::Poisoned(error)
+    }
+}
+
+impl<T> fmt::Debug for TryLockError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TryLockError::Poisoned(error) => f.debug_tuple("Poisoned").field(&error).finish(),
+            TryLockError::WouldBlock => f.debug_tuple("WouldBlock").finish(),
+        }
+    }
+}
+
+impl<T> fmt::Display for TryLockError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TryLockError::Poisoned(error) => {
+                write!(f, "poisoned lock {:?}", DebugFlags(error.flags))
+            }
+            TryLockError::WouldBlock => {
+                f.write_str("try_lock failed because the operation would block")
+            }
+        }
+    }
+}
+
+impl<T> error::Error for TryLockError<T> {
+    fn cause(&self) -> Option<&dyn error::Error> {
+        match self {
+            TryLockError::Poisoned(error) => Some(error),
+            TryLockError::WouldBlock => None,
+        }
+    }
+}
+
+/// A type alias for the result of a lock method which can be poisoned.
+///
+/// The [`Ok`] variant of this result indicates that the primitive was not
+/// poisoned, and the `Guard` is contained within. The [`Err`] variant indicates
+/// that the primitive was poisoned. Note that the [`Err`] variant *also* carries
+/// the associated guard, and it can be acquired through the [`into_inner`]
+/// method.
+///
+/// [`into_inner`]: PoisonError::into_inner
+pub type LockResult<Guard> = Result<Guard, PoisonError<Guard>>;
+
+/// A type alias for the result of a nonblocking locking method.
+///
+/// For more information, see [`LockResult`]. A `TryLockResult` doesn't
+/// necessarily hold the associated guard in the [`Err`] type as the lock might not
+/// have been acquired for other reasons.
+pub type TryLockResult<Guard> = Result<Guard, TryLockError<Guard>>;
+
+pub const NO_POISON: u8 = 0;
+pub const PANIC_POISON: u8 = 1 << 0;
+pub const CANCEL_POISON: u8 = 1 << 1;
+
 pub struct Flag {
-    failed: AtomicBool,
+    failed: AtomicU8,
+}
+
+impl fmt::Debug for Flag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let flags = self.failed.load(Ordering::Relaxed);
+        DebugFlags(flags).fmt(f)
+    }
 }
 
 // Note that the Ordering uses to access the `failed` field of `Flag` below is always `Relaxed`, and
@@ -26,42 +167,42 @@ impl Flag {
     #[inline]
     pub const fn new() -> Flag {
         Flag {
-            failed: AtomicBool::new(false),
+            failed: AtomicU8::new(NO_POISON),
         }
     }
 
     /// Check the flag for an unguarded borrow, where we only care about existing poison.
     #[inline]
     pub fn borrow(&self) -> LockResult<()> {
-        if self.get() {
-            Err(PoisonError::new(()))
+        let flags = self.get_flags();
+        if flags > NO_POISON {
+            Err(PoisonError::new((), flags))
         } else {
             Ok(())
         }
     }
 
-    /// Check the flag for a guarded borrow, where we may also set poison when `done`.
     #[inline]
-    pub fn guard(&self) -> LockResult<Guard> {
-        let ret = Guard {
+    pub fn guard_assuming_no_poison(&self) -> Guard {
+        Guard {
             panicking: thread::panicking(),
-        };
-        if self.get() {
-            Err(PoisonError::new(ret))
-        } else {
-            Ok(ret)
         }
     }
 
     #[inline]
-    pub fn done(&self, guard: &Guard) {
+    pub fn done(&self, guard: &Guard, cancel_poison: bool) {
+        let mut new_flags = 0;
         if !guard.panicking && thread::panicking() {
-            self.failed.store(true, Ordering::Relaxed);
+            new_flags |= PANIC_POISON;
         }
+        if cancel_poison {
+            new_flags |= CANCEL_POISON;
+        }
+        self.failed.fetch_or(new_flags, Ordering::Relaxed);
     }
 
     #[inline]
-    pub fn get(&self) -> bool {
+    pub fn get_flags(&self) -> u8 {
         self.failed.load(Ordering::Relaxed)
     }
 }
@@ -76,6 +217,29 @@ where
 {
     match result {
         Ok(t) => Ok(f(t)),
-        Err(error) => Err(PoisonError::new(f(error.into_inner()))),
+        Err(error) => {
+            let flags = error.flags;
+            Err(PoisonError::new(f(error.into_inner()), flags))
+        }
+    }
+}
+
+struct DebugFlags(u8);
+
+impl fmt::Debug for DebugFlags {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.0 == NO_POISON {
+            write!(f, "(not poisoned)")
+        } else {
+            let mut poisoned_by = Vec::new();
+            if self.0 & PANIC_POISON != 0 {
+                poisoned_by.push("panic");
+            }
+            if self.0 & CANCEL_POISON != 0 {
+                poisoned_by.push("cancellation");
+            }
+
+            write!(f, "(poisoned by {})", poisoned_by.join(", "))
+        }
     }
 }

--- a/src/sync/poison.rs
+++ b/src/sync/poison.rs
@@ -24,29 +24,34 @@ impl<T> PoisonError<T> {
 
     /// Returns true if this error indicates that the lock was poisoned by a
     /// panic from another task.
+    #[inline]
     pub fn is_panic(&self) -> bool {
         self.flags & PANIC_POISON != 0
     }
 
     /// Returns true if this error indicates that the lock was poisoned by an early cancellation.
+    #[inline]
     pub fn is_cancel(&self) -> bool {
         self.flags & CANCEL_POISON != 0
     }
 
     /// Consumes this error indicating that a lock is poisoned, returning the
     /// underlying guard to allow access regardless.
+    #[inline]
     pub fn into_inner(self) -> T {
         self.guard
     }
 
     /// Reaches into this error indicating that a lock is poisoned, returning a
     /// reference to the underlying guard to allow access regardless.
+    #[inline]
     pub fn get_ref(&self) -> &T {
         &self.guard
     }
 
     /// Reaches into this error indicating that a lock is poisoned, returning a
     /// mutable reference to the underlying guard to allow access regardless.
+    #[inline]
     pub fn get_mut(&mut self) -> &mut T {
         &mut self.guard
     }

--- a/tests/integration_tests/main.rs
+++ b/tests/integration_tests/main.rs
@@ -1,3 +1,4 @@
 mod coop_cancel;
 mod join_all_then_try;
 mod macros_join_then_try;
+mod sync_mutex;

--- a/tests/integration_tests/sync_mutex.rs
+++ b/tests/integration_tests/sync_mutex.rs
@@ -1,11 +1,12 @@
 #![cfg(feature = "std")]
 
 use cancel_safe_futures::sync::Mutex;
-use std::sync::{Arc, TryLockError};
-use std::time::Duration;
+use std::{
+    sync::{Arc, TryLockError},
+    time::Duration,
+};
 use tokio::time::{interval, timeout};
-use tokio_test::task::spawn;
-use tokio_test::{assert_pending, assert_ready};
+use tokio_test::{assert_pending, assert_ready, task::spawn};
 
 #[test]
 fn straight_execution() {

--- a/tests/integration_tests/sync_mutex.rs
+++ b/tests/integration_tests/sync_mutex.rs
@@ -1,0 +1,190 @@
+#![cfg(feature = "std")]
+
+use cancel_safe_futures::sync::Mutex;
+use std::sync::{Arc, TryLockError};
+use std::time::Duration;
+use tokio::time::{interval, timeout};
+use tokio_test::task::spawn;
+use tokio_test::{assert_pending, assert_ready};
+
+#[test]
+fn straight_execution() {
+    let l = Mutex::new(100);
+
+    {
+        let mut t = spawn(l.lock());
+        let permit = assert_ready!(t.poll()).unwrap();
+        permit.perform(|g| {
+            assert_eq!(&*g, &100);
+            *g = 99;
+        });
+    }
+    {
+        let mut t = spawn(l.lock());
+        let permit = assert_ready!(t.poll()).unwrap();
+        permit.perform(|g| {
+            assert_eq!(&*g, &99);
+            *g = 98;
+        });
+    }
+    {
+        let mut t = spawn(l.lock());
+        let permit = assert_ready!(t.poll()).unwrap();
+        permit.perform(|g| {
+            assert_eq!(&*g, &98);
+        });
+    }
+}
+
+#[test]
+fn readiness() {
+    let l1 = Arc::new(Mutex::new(100));
+    let l2 = Arc::clone(&l1);
+    let mut t1 = spawn(l1.lock());
+    let mut t2 = spawn(l2.lock());
+
+    let g = assert_ready!(t1.poll()).unwrap();
+
+    // We can't now acquire the lease since it's already held in g
+    assert_pending!(t2.poll());
+
+    // But once g unlocks, we can acquire it
+    drop(g);
+    assert!(t2.is_woken());
+    let _t2 = assert_ready!(t2.poll()).unwrap();
+}
+
+/// Ensure a mutex is unlocked if a future holding the lock is aborted prematurely.
+///
+/// This does not provide internal access to the data held by the mutex, so concerns about invariant
+/// violations don't apply.
+#[tokio::test]
+async fn aborted_future_1() {
+    let m1: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
+    {
+        let m2 = m1.clone();
+        // Try to lock mutex in a future that is aborted prematurely
+        timeout(Duration::from_millis(1u64), async move {
+            let iv = interval(Duration::from_millis(1000));
+            tokio::pin!(iv);
+            let _g = m2.lock().await.unwrap();
+            iv.as_mut().tick().await;
+            iv.as_mut().tick().await;
+        })
+        .await
+        .unwrap_err();
+    }
+    // This should succeed as there is no lock left for the mutex.
+    timeout(Duration::from_millis(1u64), async move {
+        let _g = m1.lock().await.unwrap();
+    })
+    .await
+    .expect("Mutex is locked");
+}
+
+/// This test is similar to `aborted_future_1` but this time the aborted future is waiting for the
+/// lock.
+#[tokio::test]
+async fn aborted_future_2() {
+    let m1: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
+    {
+        // Lock mutex
+        let _lock = m1.lock().await;
+        {
+            let m2 = m1.clone();
+            // Try to lock mutex in a future that is aborted prematurely
+            timeout(Duration::from_millis(1u64), async move {
+                let _g = m2.lock().await.unwrap();
+            })
+            .await
+            .unwrap_err();
+        }
+    }
+    // This should succeed as there is no lock left for the mutex.
+    timeout(Duration::from_millis(1u64), async move {
+        let _g = m1.lock().await.unwrap();
+    })
+    .await
+    .expect("Mutex is locked");
+}
+
+/// Ensure a mutex is poisoned if a task panics in the middle of perform.
+#[tokio::test]
+async fn panicking_task() {
+    let m1: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
+    {
+        let m2 = m1.clone();
+        tokio::task::spawn(async move {
+            let permit = m2.lock().await.unwrap();
+            permit.perform(|_| {
+                panic!("oh no!");
+            });
+        })
+        .await
+        .unwrap_err();
+    }
+    // This returns a PoisonError.
+    m1.lock().await.unwrap_err();
+
+    // This returns a TryLockError of the Poisoned kind.
+    let error = m1.try_lock().unwrap_err();
+    assert!(matches!(error, TryLockError::Poisoned(_)));
+}
+
+#[test]
+fn try_lock() {
+    let m: Mutex<usize> = Mutex::new(0);
+    {
+        let g1 = m.try_lock();
+        assert!(g1.is_ok());
+        let g2 = m.try_lock();
+        assert!(g2.is_err());
+    }
+    let g3 = m.try_lock();
+    assert!(g3.is_ok());
+}
+
+#[tokio::test]
+async fn mutex_guard_debug_display() {
+    let s = "internal";
+    let m = Mutex::new(s.to_string());
+    let permit = m.lock().await.unwrap();
+    assert_eq!(format!("{:?}", s), format!("{:?}", permit));
+    assert_eq!(s, format!("{}", permit));
+}
+
+#[tokio::test]
+async fn mutex_debug_display() {
+    let s = "data";
+    let m = Arc::new(Mutex::new(s.to_string()));
+    assert_eq!(
+        format!("{:?}", m),
+        r#"Mutex { data: "data", poisoned: false }"#
+    );
+    let _permit = m.lock().await.unwrap();
+    assert_eq!(
+        format!("{:?}", m),
+        r#"Mutex { data: <locked>, poisoned: false }"#
+    );
+    std::mem::drop(_permit);
+    assert_eq!(
+        format!("{:?}", m),
+        r#"Mutex { data: "data", poisoned: false }"#
+    );
+
+    // Panic in the middle of perform.
+    let m2 = m.clone();
+    tokio::task::spawn(async move {
+        let permit = m2.lock().await.unwrap();
+        permit.perform(|_| {
+            panic!("oh no!");
+        });
+    })
+    .await
+    .unwrap_err();
+
+    assert_eq!(
+        format!("{:?}", m),
+        r#"Mutex { data: <locked>, poisoned: true }"#
+    );
+}


### PR DESCRIPTION
See the documentation in `src/sync/mutex.rs` for more.

TODO:

- [x] Add documentation and comments about lock poisoning
- [x] Add example-based tests
- [x] Add tests for lock poisoning
- [x] Figure out licensing situation since I was looking at lilos's code while writing it

Questions:

- [x] Should the mutexes be marked poisoned if they panic outside of `perform`? Is there a different answer for `MappedActionPermit`?
  - Went with "no" here -- only panics inside `perform` result in poisons. I also removed `MappedActionPermit` because I think the semantics don't translate well (what if you violate invariants in the map operation?) and I think it's of limited use.